### PR TITLE
FIX: DIND

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y \
         # https://github.com/ruby/setup-ruby#using-self-hosted-runners
         libyaml-dev \
         # dockerd dependencies
+        kmod \
         tini \
         iptables
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "RUN_DOCKERD" = "true" ]; then
+if [ "$RUN_DOCKERD" = "true" ]; then
   sudo /usr/bin/dockerd &
 fi
 


### PR DESCRIPTION
* Load DIND based on the RUN_DOCKERD environment variable. Previously it would never start due to static string comparisson (the value of variable was never interpolated).
* Include `kmod` to allow the `modprobe` command to load iptables when starting dockerd. Previously the `modprobe` command was unavailable.
  * adds support for DIND in cases where the host's kernel does not have iptables loaded. Requires the SYS_MODULE capability